### PR TITLE
Added support for file buffer objects

### DIFF
--- a/pdfid/pdfid.py
+++ b/pdfid/pdfid.py
@@ -386,7 +386,7 @@ def ParseINIFile():
                 keywords.append(key)
     return keywords
 
-def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, output=None, fileBuff=b""):
+def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, output=None, filebuffer=None):
     """Example of XML output:
     <PDFiD ErrorOccured="False" ErrorMessage="" Filename="test.pdf" Header="%PDF-1.1" IsPDF="True" Version="0.0.4" Entropy="4.28">
             <Keywords>
@@ -458,8 +458,8 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
     try:
         attIsPDF = xmlDoc.createAttribute('IsPDF')
         xmlDoc.documentElement.setAttributeNode(attIsPDF)
-        if fileBuff != b"":
-            oBinaryFile = cBinaryFile(fileBuff)
+        if filebuffer is not None:
+            oBinaryFile = cBinaryFile(filebuffer)
         else:
             oBinaryFile = cBinaryFile(file)
         if extraData:
@@ -795,8 +795,8 @@ def MakeCSVLine(fields, separator=';', quote='"'):
     strings = [Quote(field[1], separator, quote) for field in fields]
     return formatstring % tuple(strings)
 
-def ProcessFile(filename, options, plugins, list_of_dict, filebuffer=b""):
-    xmlDoc = PDFiD(filename, options.all, options.extra, options.disarm, options.force, fileBuff=filebuffer)
+def ProcessFile(filename, options, plugins, list_of_dict, filebuffer=None):
+    xmlDoc = PDFiD(filename, options.all, options.extra, options.disarm, options.force, filebuffer=filebuffer)
     if plugins == [] and options.select == '':
         PDFID2Dict(xmlDoc, options.nozero, options.force, list_of_dict)
         Print(PDFiD2String(xmlDoc, options.nozero, options.force), options)
@@ -857,7 +857,7 @@ def ProcessFile(filename, options, plugins, list_of_dict, filebuffer=b""):
                     Print(PDFiD2String(xmlDoc, options.nozero, options.force), options)
 
 
-def Scan(directory, options, plugins, filename_dict, filebuffer=b""):
+def Scan(directory, options, plugins, filename_dict, filebuffer=None):
     try:
         if os.path.isdir(directory):
             for entry in os.listdir(directory):

--- a/pdfid/pdfid.py
+++ b/pdfid/pdfid.py
@@ -1067,8 +1067,8 @@ def PDFiDMain(filenames, options, filebuffers=[]):
     }
 
     if filebuffers:
-        for filebuffer in filebuffers:
-            ProcessFile("analyzing.pdf", options, plugins, list_of_dict["reports"], filebuffer)
+        for i, filebuffer in enumerate(filebuffers):
+            ProcessFile(filenames[i], options, plugins, list_of_dict["reports"], filebuffer)
     else:
         for filename in filenames:
             if options.scan:

--- a/pdfid/pdfid.py
+++ b/pdfid/pdfid.py
@@ -1051,7 +1051,7 @@ def LoadPlugins(plugins, verbose):
             if verbose:
                 raise e
 
-def PDFiDMain(filenames, options, filebuffers=[]):
+def PDFiDMain(filenames, options, filebuffers=None):
     global plugins
     plugins = []
     LoadPlugins(options.plugins, options.verbose)
@@ -1066,15 +1066,15 @@ def PDFiDMain(filenames, options, filebuffers=[]):
         "reports": []
     }
 
-    if filebuffers:
-        for i, filebuffer in enumerate(filebuffers):
-            ProcessFile(filenames[i], options, plugins, list_of_dict["reports"], filebuffer)
-    else:
+    if not filebuffers:
         for filename in filenames:
             if options.scan:
                 Scan(filename, options, plugins, list_of_dict["reports"])
             else:
                 ProcessFile(filename, options, plugins, list_of_dict["reports"])
+    else:
+        for i, filebuffer in enumerate(filebuffers):
+            ProcessFile(filenames[i], options, plugins, list_of_dict["reports"], filebuffer)
 
     if options.json:
         return list_of_dict

--- a/pdfid/pdfid.py
+++ b/pdfid/pdfid.py
@@ -77,6 +77,7 @@ import zipfile
 import collections
 import glob
 import fnmatch
+import io
 if sys.version_info[0] >= 3:
     import urllib.request as urllib23
 else:
@@ -98,6 +99,8 @@ class cBinaryFile:
         self.file = file
         if file == '':
             self.infile = sys.stdin
+        elif isinstance(file, bytes):
+            self.infile = io.BytesIO(file)
         elif file.lower().startswith('http://') or file.lower().startswith('https://'):
             try:
                 if sys.hexversion >= 0x020601F0:
@@ -383,7 +386,7 @@ def ParseINIFile():
                 keywords.append(key)
     return keywords
 
-def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, output=None):
+def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, output=None, fileBuff=b""):
     """Example of XML output:
     <PDFiD ErrorOccured="False" ErrorMessage="" Filename="test.pdf" Header="%PDF-1.1" IsPDF="True" Version="0.0.4" Entropy="4.28">
             <Keywords>
@@ -455,7 +458,10 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
     try:
         attIsPDF = xmlDoc.createAttribute('IsPDF')
         xmlDoc.documentElement.setAttributeNode(attIsPDF)
-        oBinaryFile = cBinaryFile(file)
+        if fileBuff != b"":
+            oBinaryFile = cBinaryFile(fileBuff)
+        else:
+            oBinaryFile = cBinaryFile(file)
         if extraData:
             oPDFDate = cPDFDate()
             oEntropy = cEntropy()
@@ -789,8 +795,8 @@ def MakeCSVLine(fields, separator=';', quote='"'):
     strings = [Quote(field[1], separator, quote) for field in fields]
     return formatstring % tuple(strings)
 
-def ProcessFile(filename, options, plugins, list_of_dict):
-    xmlDoc = PDFiD(filename, options.all, options.extra, options.disarm, options.force)
+def ProcessFile(filename, options, plugins, list_of_dict, filebuffer=b""):
+    xmlDoc = PDFiD(filename, options.all, options.extra, options.disarm, options.force, fileBuff=filebuffer)
     if plugins == [] and options.select == '':
         PDFID2Dict(xmlDoc, options.nozero, options.force, list_of_dict)
         Print(PDFiD2String(xmlDoc, options.nozero, options.force), options)
@@ -851,13 +857,13 @@ def ProcessFile(filename, options, plugins, list_of_dict):
                     Print(PDFiD2String(xmlDoc, options.nozero, options.force), options)
 
 
-def Scan(directory, options, plugins, filename_dict):
+def Scan(directory, options, plugins, filename_dict, filebuffer=b""):
     try:
         if os.path.isdir(directory):
             for entry in os.listdir(directory):
-                Scan(os.path.join(directory, entry), options, plugins, filename_dict)
+                Scan(os.path.join(directory, entry), options, plugins, filename_dict, filebuffer)
         else:
-            ProcessFile(directory, options, plugins, filename_dict)
+            ProcessFile(directory, options, plugins, filename_dict, filebuffer)
     except Exception as e:
 #        print directory
         print(e)
@@ -1045,7 +1051,7 @@ def LoadPlugins(plugins, verbose):
             if verbose:
                 raise e
 
-def PDFiDMain(filenames, options):
+def PDFiDMain(filenames, options, filebuffers=[]):
     global plugins
     plugins = []
     LoadPlugins(options.plugins, options.verbose)
@@ -1059,11 +1065,16 @@ def PDFiDMain(filenames, options):
     list_of_dict = {
         "reports": []
     }
-    for filename in filenames:
-        if options.scan:
-            Scan(filename, options, plugins, list_of_dict["reports"])
-        else:
-            ProcessFile(filename, options, plugins, list_of_dict["reports"])
+
+    if filebuffers:
+        for filebuffer in filebuffers:
+            ProcessFile("analyzing.pdf", options, plugins, list_of_dict["reports"], filebuffer)
+    else:
+        for filename in filenames:
+            if options.scan:
+                Scan(filename, options, plugins, list_of_dict["reports"])
+            else:
+                ProcessFile(filename, options, plugins, list_of_dict["reports"])
 
     if options.json:
         return list_of_dict

--- a/test.py
+++ b/test.py
@@ -7,16 +7,16 @@ def main():
     options.scan = True
     options.json = True
 
-    # Analyze PDF from filenames
+    # 1. Analyze PDF from filenames
     list_of_dict = pdfid.PDFiDMain(filenames, options)
     print(list_of_dict)
 
-    # Analyze PDF from buffer
+    # 2. Analyze PDF from buffer
     file_buffers = []
     for filename in filenames:
         with open(filename, "rb") as f:
             file_buffers.append(f.read())
-    list_of_dict = pdfid.PDFiDMain([], options, file_buffers)
+    list_of_dict = pdfid.PDFiDMain(filenames, options, file_buffers)
     print(list_of_dict)
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -6,9 +6,18 @@ def main():
     options = pdfid.get_fake_options()
     options.scan = True
     options.json = True
+
+    # Analyze PDF from filenames
     list_of_dict = pdfid.PDFiDMain(filenames, options)
     print(list_of_dict)
 
+    # Analyze PDF from buffer
+    file_buffers = []
+    for filename in filenames:
+        with open(filename, "rb") as f:
+            file_buffers.append(f.read())
+    list_of_dict = pdfid.PDFiDMain([], options, file_buffers)
+    print(list_of_dict)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR now supports to instantiate a `pdfid.PDFiDMain()` object from file buffer objects.

Instead of just passing filenames, it now supports objects already in memory as shown below.
```python
filenames = ["./test"]
options = pdfid.get_fake_options()
options.scan = True
options.json = True

file_buffers = []
for filename in filenames:
    with open(filename, "rb") as f:
        file_buffers.append(f.read())

# PDFiDMain now takes file_buffers as its third parameter
list_of_dict = pdfid.PDFiDMain(filenames, options, file_buffers)
print(list_of_dict)
```