### PR TITLE
Added support for disarming files in memory

### DIFF
--- a/pdfid/pdfid.py
+++ b/pdfid/pdfid.py
@@ -525,20 +525,20 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
                     else:
                         oBinaryFile.unget(d2)
                         oBinaryFile.unget(d1)
-                        (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut)
+                        (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut, disarmed_pdf_buffer)
                         if disarm:
                             fOut.write(C2BIP3(char))
                             disarmed_pdf_buffer.write(C2BIP3(char))
                 else:
                     oBinaryFile.unget(d1)
-                    (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut)
+                    (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut, disarmed_pdf_buffer)
                     if disarm:
                         fOut.write(C2BIP3(char))
                         disarmed_pdf_buffer.write(C2BIP3(char))
             else:
                 oCVE_2009_3459.Check(lastName, word)
 
-                (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut)
+                (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut, disarmed_pdf_buffer)
                 if char == '/':
                     slash = '/'
                 else:
@@ -557,7 +557,7 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
                 oPDFEOF.parse(char)
 
             byte = oBinaryFile.byte()
-        (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut)
+        (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut, disarmed_pdf_buffer)
 
         # check to see if file ended with %%EOF.  If so, we can reset charsAfterLastEOF and add one to EOF count.  This is never performed in
         # the parse function because it never gets called due to hitting the end of file.
@@ -579,7 +579,7 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
     
     if disarm:
         disarmed_filebuffers.append(disarmed_pdf_buffer.getvalue())
-        disarmed_pdf_buffer.close()
+        # disarmed_pdf_buffer.close()
 
     attEntropyAll = xmlDoc.createAttribute('TotalEntropy')
     xmlDoc.documentElement.setAttributeNode(attEntropyAll)

--- a/pdfid/pdfid.py
+++ b/pdfid/pdfid.py
@@ -572,14 +572,13 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
     except:
         attErrorOccured.nodeValue = 'True'
         attErrorMessage.nodeValue = traceback.format_exc()
-
-    if disarm and not output:
-        fOut.close()
-
     
     if disarm:
         disarmed_filebuffers.append(disarmed_pdf_buffer.getvalue())
-        # disarmed_pdf_buffer.close()
+
+    if disarm and not output:
+        fOut.close()
+        disarmed_pdf_buffer.close()
 
     attEntropyAll = xmlDoc.createAttribute('TotalEntropy')
     xmlDoc.documentElement.setAttributeNode(attEntropyAll)

--- a/pdfid/pdfid.py
+++ b/pdfid/pdfid.py
@@ -325,7 +325,7 @@ def HexcodeName2String(hexcodeName):
 def SwapName(wordExact):
     return map(SwapCase, wordExact)
 
-def UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut):
+def UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut, disarmed_buffer=None):
     if word != '':
         if slash + word in words:
             words[slash + word][0] += 1
@@ -349,9 +349,13 @@ def UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insi
             if slash == '/' and '/' + word in ('/JS', '/JavaScript', '/AA', '/OpenAction', '/JBIG2Decode', '/RichMedia', '/Launch'):
                 wordExactSwapped = HexcodeName2String(SwapName(wordExact))
                 fOut.write(C2BIP3(wordExactSwapped))
+                if disarmed_buffer is not None:
+                    disarmed_buffer.write(C2BIP3(wordExactSwapped))
                 print('/%s -> /%s' % (HexcodeName2String(wordExact), wordExactSwapped))
             else:
                 fOut.write(C2BIP3(HexcodeName2String(wordExact)))
+                if disarmed_buffer is not None:
+                    disarmed_buffer.write(C2BIP3(HexcodeName2String(wordExact)))
     return ('', [], False, lastName, insideStream)
 
 class cCVE_2009_3459:
@@ -386,7 +390,7 @@ def ParseINIFile():
                 keywords.append(key)
     return keywords
 
-def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, output=None, filebuffer=None):
+def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, output=None, disarmed_filebuffers=None, filebuffer=None):
     """Example of XML output:
     <PDFiD ErrorOccured="False" ErrorMessage="" Filename="test.pdf" Header="%PDF-1.1" IsPDF="True" Version="0.0.4" Entropy="4.28">
             <Keywords>
@@ -468,15 +472,20 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
             oPDFEOF = cPDFEOF()
         (bytesHeader, pdfHeader) = FindPDFHeaderRelaxed(oBinaryFile)
         if disarm:
+            disarmed_pdf_buffer = io.BytesIO()
             if not output:
+                # print("Disarm activated - Generating Output file")
                 (pathfile, extension) = os.path.splitext(file)
                 fOut = open(pathfile + '.disarmed' + extension, 'wb')
             else:
+                # print("Disarm activated - Output file given")
                 fOut = output
             for byteHeader in bytesHeader:
+                disarmed_pdf_buffer.write(C2BIP3(chr(byteHeader)))
                 fOut.write(C2BIP3(chr(byteHeader)))
         else:
             fOut = None
+            disarmed_pdf_buffer = None
         if oEntropy != None:
             for byteHeader in bytesHeader:
                 oEntropy.add(byteHeader, insideStream)
@@ -519,11 +528,13 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
                         (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut)
                         if disarm:
                             fOut.write(C2BIP3(char))
+                            disarmed_pdf_buffer.write(C2BIP3(char))
                 else:
                     oBinaryFile.unget(d1)
                     (word, wordExact, hexcode, lastName, insideStream) = UpdateWords(word, wordExact, slash, words, hexcode, allNames, lastName, insideStream, oEntropy, fOut)
                     if disarm:
                         fOut.write(C2BIP3(char))
+                        disarmed_pdf_buffer.write(C2BIP3(char))
             else:
                 oCVE_2009_3459.Check(lastName, word)
 
@@ -534,6 +545,7 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
                     slash = ''
                 if disarm:
                     fOut.write(C2BIP3(char))
+                    disarmed_pdf_buffer.write(C2BIP3(char))
 
             if oPDFDate != None and oPDFDate.parse(char) != None:
                 dates.append([oPDFDate.date, lastName])
@@ -563,6 +575,11 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
 
     if disarm and not output:
         fOut.close()
+
+    
+    if disarm:
+        disarmed_filebuffers.append(disarmed_pdf_buffer.getvalue())
+        disarmed_pdf_buffer.close()
 
     attEntropyAll = xmlDoc.createAttribute('TotalEntropy')
     xmlDoc.documentElement.setAttributeNode(attEntropyAll)
@@ -795,8 +812,8 @@ def MakeCSVLine(fields, separator=';', quote='"'):
     strings = [Quote(field[1], separator, quote) for field in fields]
     return formatstring % tuple(strings)
 
-def ProcessFile(filename, options, plugins, list_of_dict, filebuffer=None):
-    xmlDoc = PDFiD(filename, options.all, options.extra, options.disarm, options.force, filebuffer=filebuffer)
+def ProcessFile(filename, options, plugins, list_of_dict, disarmed_filebuffers=None, filebuffer=None):
+    xmlDoc = PDFiD(filename, options.all, options.extra, options.disarm, options.force, disarmed_filebuffers=disarmed_filebuffers, filebuffer=filebuffer)
     if plugins == [] and options.select == '':
         PDFID2Dict(xmlDoc, options.nozero, options.force, list_of_dict)
         Print(PDFiD2String(xmlDoc, options.nozero, options.force), options)
@@ -857,13 +874,13 @@ def ProcessFile(filename, options, plugins, list_of_dict, filebuffer=None):
                     Print(PDFiD2String(xmlDoc, options.nozero, options.force), options)
 
 
-def Scan(directory, options, plugins, filename_dict, filebuffer=None):
+def Scan(directory, options, plugins, filename_dict, disarmed_filebuffer=None, filebuffer=None):
     try:
         if os.path.isdir(directory):
             for entry in os.listdir(directory):
-                Scan(os.path.join(directory, entry), options, plugins, filename_dict, filebuffer)
+                Scan(os.path.join(directory, entry), options, plugins, filename_dict, disarmed_filebuffer, filebuffer)
         else:
-            ProcessFile(directory, options, plugins, filename_dict, filebuffer)
+            ProcessFile(directory, options, plugins, filename_dict, disarmed_filebuffer, filebuffer)
     except Exception as e:
 #        print directory
         print(e)
@@ -1066,18 +1083,34 @@ def PDFiDMain(filenames, options, filebuffers=None):
         "reports": []
     }
 
+    disarmed_buffers = {
+        "buffers": []
+    }
+
     if not filebuffers:
         for filename in filenames:
             if options.scan:
-                Scan(filename, options, plugins, list_of_dict["reports"])
+                Scan(filename, options, plugins, list_of_dict["reports"], disarmed_buffers["buffers"])
             else:
-                ProcessFile(filename, options, plugins, list_of_dict["reports"])
+                ProcessFile(filename, options, plugins, list_of_dict["reports"], disarmed_buffers["buffers"])
     else:
         for i, filebuffer in enumerate(filebuffers):
-            ProcessFile(filenames[i], options, plugins, list_of_dict["reports"], filebuffer)
+            ProcessFile(filenames[i], options, plugins, list_of_dict["reports"], disarmed_buffers["buffers"], filebuffer)
+
+    results = ()
 
     if options.json:
-        return list_of_dict
+        results += (list_of_dict,)
+    
+    if options.return_disarmed_buffer:
+        results += (disarmed_buffers,)
+    
+    if len(results) == 1:
+        results = results[0]
+    
+    return results
+    
+
 
 
 def GetOTPParser():
@@ -1109,6 +1142,7 @@ def GetOTPParser():
     oParser.add_option('--recursedir', action='store_true', default=False, help='Recurse directories (wildcards and here files (@...) allowed)')
     oParser.add_option('-j', '--json', action='store_true', default=False,
                        help='json output, supports only basic analysis')
+    oParser.add_option('-b', '--return_disarmed_buffer', action='store_true', default=False, help='Returns the disarmed pdf documents as buffer objects.')
     return oParser
 
 
@@ -1131,6 +1165,7 @@ def get_fake_options():
             self.literalfilenames = False
             self.recursedir = False
             self.json = False
+            self.return_disarmed_buffer = False
 
     fakeoptions = FakeOptions()
     return fakeoptions

--- a/test.py
+++ b/test.py
@@ -59,7 +59,6 @@ def main():
     # 3. Disarm PDF from buffer and return disarmed buffer
     print("STARTING DISARM")
     disarmed_pdf_buffers = disarm_pdfs_by_buffer(filenames, file_buffers)
-    print(f"{disarmed_pdf_buffers['buffers'][0][:100]=}")
 
     # 3.1 Analyze PDF from disarmed buffer
     print("STARTING DISARMED ANALYSIS")

--- a/test.py
+++ b/test.py
@@ -1,23 +1,70 @@
+import pprint
 from pdfid import pdfid
 
+pp = pprint.PrettyPrinter(indent=4)
 
-def main():
-    filenames = ["./test"]
+TEST_FILENAME = "./JavaScriptClock.pdf"
+
+def analyze_pdfs_by_filenames(filenames):
+    # 1. Setup
     options = pdfid.get_fake_options()
     options.scan = True
     options.json = True
 
-    # 1. Analyze PDF from filenames
+    # 2. Actual analysis
     list_of_dict = pdfid.PDFiDMain(filenames, options)
-    print(list_of_dict)
 
-    # 2. Analyze PDF from buffer
+    return list_of_dict
+
+def analyze_pdfs_by_buffer(filenames, file_buffers):
+    # 1. Setup
+    options = pdfid.get_fake_options()
+    options.scan = True
+    options.json = True
+
+    # 2. Actual analysis
+    list_of_dict = pdfid.PDFiDMain(filenames, options, file_buffers)
+    return list_of_dict
+
+def disarm_pdfs_by_buffer(filenames, file_buffers):
+    # 1. Setup
+    options = pdfid.get_fake_options()
+
+    options.disarm = True
+    # If you want to return the disarmed buffer 
+    # instead of the results dict, set this to True
+    options.return_disarmed_buffer = True
+
+    # 2. Actual analysis + disarm
+    disarmed_pdf_buffers = pdfid.PDFiDMain(filenames, options, file_buffers)
+    return disarmed_pdf_buffers
+
+def main():
+    filenames = [TEST_FILENAME]
     file_buffers = []
     for filename in filenames:
         with open(filename, "rb") as f:
             file_buffers.append(f.read())
-    list_of_dict = pdfid.PDFiDMain(filenames, options, file_buffers)
-    print(list_of_dict)
+
+    # 1. Analyze PDF from filenames
+    print("STARTING ANALYSIS 1")
+    results_1 = analyze_pdfs_by_filenames(filenames)
+    pp.pprint(results_1)
+
+    # 2. Analyze PDF from buffer
+    print("STARTING ANALYSIS 2")
+    results_2 = analyze_pdfs_by_buffer(filenames, file_buffers)
+    pp.pprint(results_2)
+
+    # 3. Disarm PDF from buffer and return disarmed buffer
+    print("STARTING DISARM")
+    disarmed_pdf_buffers = disarm_pdfs_by_buffer(filenames, file_buffers)
+    print(f"{disarmed_pdf_buffers['buffers'][0][:100]=}")
+
+    # 3.1 Analyze PDF from disarmed buffer
+    print("STARTING DISARMED ANALYSIS")
+    results_3 = analyze_pdfs_by_buffer(filenames, disarmed_pdf_buffers['buffers'])
+    pp.pprint(results_3)
 
 if __name__ == '__main__':
     main()

--- a/test.py
+++ b/test.py
@@ -3,7 +3,7 @@ from pdfid import pdfid
 
 pp = pprint.PrettyPrinter(indent=4)
 
-TEST_FILENAME = "./test"
+TEST_FILENAME = "./JavaScriptClock.pdf"
 
 def analyze_pdfs_by_filenames(filenames):
     # 1. Setup

--- a/test.py
+++ b/test.py
@@ -3,7 +3,7 @@ from pdfid import pdfid
 
 pp = pprint.PrettyPrinter(indent=4)
 
-TEST_FILENAME = "./JavaScriptClock.pdf"
+TEST_FILENAME = "./test"
 
 def analyze_pdfs_by_filenames(filenames):
     # 1. Setup


### PR DESCRIPTION
This PR now supports to disarm PDF files from buffer objects and returns the respective disarmed buffer.

```python
options = pdfid.get_fake_options()
options.disarm = True
options.return_disarmed_buffer = True

disarmed_pdf_buffers = pdfid.PDFiDMain(filenames, options, file_buffers)
```

As an example, disarming a PDF file with these properties:
```python
{   'reports': [   {   '/AA': 1,
                       '/AcroForm': 1,
                       '/Colors > 2^24': 0,
                       '/EmbeddedFile': 0,
                       '/Encrypt': 0,
                       '/JBIG2Decode': 0,
                       '/JS': 26,
                       '/JavaScript': 27,
                       '/Launch': 0,
                       '/ObjStm': 2,
                       '/OpenAction': 0,
                       '/Page': 1,
                       '/RichMedia': 0,
                       '/XFA': 0,
                       'endobj': 156,
                       'endstream': 55,
                       'filename': './test',
                       'header': '%PDF-1.6',
                       'obj': 156,
                       'startxref': 1,
                       'stream': 55,
                       'trailer': 2,
                       'version': '0.2.7',
                       'xref': 2}]}
```

Would result in a disarmed file as follows:
```python
{   'reports': [   {   '/AA': 0,
                       '/AcroForm': 1,
                       '/Colors > 2^24': 0,
                       '/EmbeddedFile': 0,
                       '/Encrypt': 0,
                       '/JBIG2Decode': 0,
                       '/JS': 0,
                       '/JavaScript': 0,
                       '/Launch': 0,
                       '/ObjStm': 2,
                       '/OpenAction': 0,
                       '/Page': 1,
                       '/RichMedia': 0,
                       '/XFA': 0,
                       'endobj': 156,
                       'endstream': 55,
                       'filename': './test',
                       'header': '%PDF-1.6',
                       'obj': 156,
                       'startxref': 1,
                       'stream': 55,
                       'trailer': 2,
                       'version': '0.2.7',
                       'xref': 2}]}
```