### PR TITLE
fix: passing disarmed buffer out

### DIFF
--- a/pdfid/pdfid.py
+++ b/pdfid/pdfid.py
@@ -414,7 +414,7 @@ def PDFiD(file, allNames=False, extraData=False, disarm=False, force=False, outp
             </Dates>
     </PDFiD>
     """
-    if not disarmed_filebuffers:
+    if disarmed_filebuffers is None:
         disarmed_filebuffers = []
 
     word = ''


### PR DESCRIPTION
Hi, I looked into the code, `if not disarmed_filebuffers:` will always equal to `False`, and after `disarmed_filebuffers = []` was executed, `disarmed_filebuffers` was changed to point to a newly created list, so any changes to it are not passed to the original `disarmed_filebuffers` list. 

I believe this will address issue #7.